### PR TITLE
Mostrar días restantes y hora utc

### DIFF
--- a/weblaruex/timetrackpro/templates/home.html
+++ b/weblaruex/timetrackpro/templates/home.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row d-flex justify-content-end">
-  <div class="col-xl-3 col-sm-6 mb-xl-0 mb-4">
+  <div class="col-xl-4 col-sm-6 mb-xl-0 mb-4">
     <div class="card">
       <div class="card-body p-3">
         <div class="row">
@@ -13,10 +13,16 @@
             <div class="numbers">
               <p class="text-sm mb-0 text-capitalize font-weight-bold">Días asuntos propios restantes</p>
               <h5 class="font-weight-bolder mb-0">
+                
+                {% if diasPropiosRestantes != 0 %}
                 {{diasPropiosRestantes}}
-                {% if diasPropiosSolicitados != 0 %}
-                <span class="text-danger text-sm font-weight-bolder">-{{diasPropiosSolicitados}}</span>
+                  {% if diasPropiosSolicitados != 0 %}
+                  <span class="text-danger text-sm font-weight-bolder">-{{diasPropiosSolicitados}}</span>
+                  {% endif %}
+                {% else %}
+                <span class="text-danger text-gradient font-weight-bolder">Sin días</span>
                 {% endif %}
+                
               </h5>
             </div>
           </div>
@@ -29,17 +35,22 @@
       </div>
     </div>
   </div>
-  <div class="col-xl-3 col-sm-6 mb-xl-0">
+  <div class="col-xl-4 col-sm-6 mb-xl-0">
     <div class="card">
       <div class="card-body p-3">
         <div class="row">
           <div class="col-8">
             <div class="numbers">
-              <p class="text-sm mb-0 text-capitalize font-weight-bold">Días de vacaciones restantes</p>
+              <p class="text-sm mb-0 text-capitalize font-weight-bold">Días naturales de vacaciones restantes</p>
               <h5 class="font-weight-bolder mb-0">
+
+                {% if diasVacacionesRestantes != 0 %}
                 {{diasVacacionesRestantes}}
-                {% if diasVacacionesSolicitados != 0 %}
-                <span class="text-danger text-sm font-weight-bolder">-{{diasVacacionesSolicitados}}</span>
+                  {% if diasVacacionesSolicitados != 0 %}
+                  <span class="text-danger text-sm font-weight-bolder">-{{diasVacacionesSolicitados}}</span>
+                  {% endif %}
+                {% else %}
+                <span class="text-danger text-gradient font-weight-bolder">Sin días</span>
                 {% endif %}
               </h5>
             </div>


### PR DESCRIPTION
Se comprueba la zona horaria de España y se guarda esa hora al fichar.
Se han creado dos módulos que comprueban en función del año cuantos días de asuntos propios se han consumido y cuantos están solicitados.
Se han creado dos módulos que comprueban en función del año cuantos días naturales de vacaciones se han consumido y cuantos están solicitados.
